### PR TITLE
Add Cloudflare IPv6 URL

### DIFF
--- a/lists/cloudflare.py
+++ b/lists/cloudflare.py
@@ -3,7 +3,7 @@ import requests
 
 CLOUDFLARE_IP_URLS = [
     'https://www.cloudflare.com/ips-v4/',
-    'https://www.cloudflare.com/ips-v4/',
+    'https://www.cloudflare.com/ips-v6/',
     ]
 
 def update():


### PR DESCRIPTION
I saw that the Cloudflare IPv4 URL was added twice and figured that the second entry should probably have been the IPv6 URL.